### PR TITLE
Add support for arm64 architecture in SDK installer

### DIFF
--- a/google/google-cloud-sdk/tasks/google-cloud-sdk-installer/index.ts
+++ b/google/google-cloud-sdk/tasks/google-cloud-sdk-installer/index.ts
@@ -112,6 +112,10 @@ function getFileName(version: string): string {
         case "x32":
             architecture = "x86";
             break;
+
+        case "arm64":
+            architecture = "arm";
+            break;
         
         default:
             throw `Architecture ${os.arch()} is not supported`;


### PR DESCRIPTION
This pull request includes a small change to the `google/google-cloud-sdk/tasks/google-cloud-sdk-installer/index.ts` file. The change adds support for the `arm64` architecture in the `getFileName` function.

* [`google/google-cloud-sdk/tasks/google-cloud-sdk-installer/index.ts`](diffhunk://#diff-560aa4fd49c27ffba36ad9ac5d267c3ffe2c650b62a06a1af638016182b63abbR116-R119): Added a case for `arm64` architecture to set `architecture` to "arm".